### PR TITLE
Add option to mark items belonging to tracked sets

### DIFF
--- a/DescendantsSupportSetTracker.lua
+++ b/DescendantsSupportSetTracker.lua
@@ -20,6 +20,7 @@ local LEGENDARY_GOLD = ZO_ColorDef:New("ffd817")
 DSST.hidden = true
 DSST.gSetList = nil
 DSST.libSetsReady = false
+DSST.markItems = true
 DSST.s2h = false
 DSST.fullSetTable = {}
 DSST.custSetList = {}
@@ -329,6 +330,64 @@ SLASH_COMMANDS["/dsst"] = function (extra)
 	DSST.showWindow()
 end
 
+local function addIndicator(control)
+	local data = control.dataEntry.data
+	local bagId = data.bagId
+	local slotIndex = data.slotIndex
+	local itemLink = bagId and GetItemLink(bagId, slotIndex) or GetItemLink(slotIndex)
+
+    local isSet, setName, setId, numBonuses, numEquipped, maxEquipped = LibSets.IsSetByItemLink(itemLink)
+
+	local indicatorControl = control:GetNamedChild("DSSTIndicator")
+	if not indicatorControl then
+        indicatorControl = WINDOW_MANAGER:CreateControl(control:GetName() .. "DSSTIndicator", control, CT_TEXTURE)
+
+        indicatorControl:ClearAnchors()
+        indicatorControl:SetAnchor(CENTER, control, CENTER, 140)
+        indicatorControl:SetDrawTier(DT_HIGH)
+
+        indicatorControl:SetTexture("/esoui/art/miscellaneous/gamepad/scrollbox_elevator.dds")
+        indicatorControl:SetDimensions(16, 16)
+	end
+
+    indicatorControl:SetHidden(true)
+    if not isSet or not DSST.markItems then
+        return
+    end
+
+    local setList
+    if DSST.gSetList ~= "Custom" then
+        setList = DSST.sets[DSST.gSetList]
+    else
+        setList = DSST.custSetList
+    end
+
+    for _, v in pairs(setList) do
+        if v.id == setId then
+            indicatorControl:SetHidden(false)
+            break
+        end
+    end
+end
+
+function DSST.RegisterInventoryHooks()
+	SecurePostHook(ZO_SmithingTopLevelDeconstructionPanelInventoryBackpack.dataTypes[1], "setupCallback", function(rowControl, slot)
+		addIndicator(rowControl)
+	end)
+
+	SecurePostHook(ZO_UniversalDeconstructionTopLevel_KeyboardPanelInventoryBackpack.dataTypes[1], "setupCallback", function(rowControl, slot)
+		addIndicator(rowControl)
+	end)
+
+	for _, v in pairs(PLAYER_INVENTORY.inventories) do
+		local listView = v.listView
+		if listView and listView.dataTypes and listView.dataTypes[1] then
+			SecurePostHook(listView.dataTypes[1], "setupCallback", function(rowControl, slot)
+				addIndicator(rowControl)
+			end)
+		end
+	end
+end
 
 --------------------------------------------------------------------------------
 -- INITIALIZE ADD ON 
@@ -348,6 +407,12 @@ function DSST:Initialize()
 -- SAVE IF 2H WEAPONS SHULD BE SHOWN
 	DSST.s2h = self.savedVariables.show2h or false
 	DSST.show2H(DSST.s2h)
+
+    if self.savedVariables.markItems == nil then
+        self.markItems = true
+    else
+        self.markItems = self.savedVariables.markItems
+    end
 
 --------------------------------------------------------------------------------
 -- READ CUSTOM FARMING LIST FROM SAVED VAR
@@ -392,6 +457,9 @@ function DSST:Initialize()
 --------------------------------------------------------------------------------
 -- RESTORE THE SAVED POSITION OF THE WINDOW (DESCENDANTSSUPPORTSETTRACKERUI.LUA)
 	DSST:RestorePosition()
+--------------------------------------------------------------------------------
+-- SET HOOKS TO ADD INDICATORS TO ITEMS
+    DSST.RegisterInventoryHooks()
 end
 
 function DSST.OnAddOnLoaded(event, addonName)

--- a/DescendantsSupportSetTrackerSettings.lua
+++ b/DescendantsSupportSetTrackerSettings.lua
@@ -170,6 +170,17 @@ function DSST.setupSettings()
 			type = "divider",
 			width = "full",
 		},
+        {
+            type = "checkbox",
+            name = "Mark items in inventory",
+            tooltip = "Add an icon to items in your inventory if they belong to a tracked set",
+            getFunc = function() return DSST.markItems end,
+            setFunc = function(value)
+                DSST.markItems = value
+                DSST.savedVariables.markItems = value
+            end,
+            requiresReload = false,
+        },
 		{
             type = "checkbox",
             name = "Show 2h Weapons",


### PR DESCRIPTION
This adds the feature that items which are from sets tracked by DSST will be marked with a little diamond symbol.

A setting to turn it off is also added, in case someone doesn't want this. It does default to on, though.
![2023-07-24-034752_553x194_scrot](https://github.com/gentlemansr/DescendantsSupportSetTracker/assets/265886/95d058c1-0be6-4416-a24d-8124a21d801b)
