### PR TITLE
Add option to show announcements for tracked sets

### DIFF
--- a/DescendantsSupportSetTrackerSettings.lua
+++ b/DescendantsSupportSetTrackerSettings.lua
@@ -191,6 +191,18 @@ function DSST.setupSettings()
             end,
             requiresReload = false,
         },
+        {
+            type = "checkbox",
+            name = "Display notification",
+            tooltip = "Display a notification when you enter a zone where a tracked set can be found",
+			default = false,
+            getFunc = function() return DSST.displayNotification end,
+            setFunc = function(value)
+                DSST.displayNotification = value
+                DSST.savedVariables.displayNotification = value
+            end,
+            requiresReload = false,
+        },
 		{
             type = "checkbox",
             name = "Show 2h Weapons",


### PR DESCRIPTION
With this merged and enabled, if you enter an area where a set drops that is on your DSST list, you will get an announcement in the centre of the screen notifying you of this fact.
The idea being, you are doing an RND or something, and maybe don't know by heart all locations of the sets you are collecting. This makes you aware that you are in a location where you can find useful set items and can keep an extra lookout for chests and the like.

Figuring out which sets exactly drop at your current location is not exactly trivial, so there may still be some discrepancies, but I tried my best and tested it for over a week.

Feel free to just tell me if you need anything changed.